### PR TITLE
fix(router): apply qualityFloor filter in recommend()

### DIFF
--- a/packages/model-router/src/router/recommend.ts
+++ b/packages/model-router/src/router/recommend.ts
@@ -55,9 +55,17 @@ export function recommend(
     );
   }
 
-  if (request.maxLatencyMs !== undefined) {
+if (request.maxLatencyMs !== undefined) {
     candidates = candidates.filter(
       (p) => p.medianLatencyMs <= request.maxLatencyMs!,
+    );
+  }
+
+  if (request.qualityFloor !== undefined) {
+    const taskTypeForFilter =
+      request.taskType ?? (request.prompt ? classifyTask(request.prompt) : "chat");
+    candidates = candidates.filter(
+      (p) => (p.capabilities[taskTypeForFilter] ?? 0) >= request.qualityFloor!,
     );
   }
 


### PR DESCRIPTION
## Summary
The `-q, --quality` CLI flag is parsed into `RouteRequest.qualityFloor` but `recommend()` never applies it as a candidate filter. Models below the requested quality score still appear in results.

## Reproduction (before fix)
```bash
node packages/cli/dist/index.js route chat --quality 5 --format json
```
Expected: empty rankings (no model has chat capability >= 5).
Actual: all 8 models returned.

## Fix
Added a filter step that drops any candidate whose capability score on the resolved task type is below `qualityFloor`. The filter runs alongside the existing `maxCostPerMtok` and `maxLatencyMs` filters.

## Verification
After applying the patch:
```
$ node packages/cli/dist/index.js route chat --quality 4.5 --format json
{ "rankings": [ ... only models with chat capability >= 4.5 ... ] }
$ node packages/cli/dist/index.js route chat --quality 5 --format json
{ "rankings": [], "selected": "none", "reasoning": "No models match..." }
```
## Risk
No behavioural change when `--quality` is not passed. The task-type resolution mirrors the existing logic a few lines below.

---

I have read the CLA and I agree to its terms.