### PR TITLE
fix(cost-tracker): store DB in XDG data dir with 0600 perms

### DIFF
--- a/packages/core/src/config/loader.ts
+++ b/packages/core/src/config/loader.ts
@@ -1,5 +1,6 @@
 import { readFileSync, existsSync } from "node:fs";
-import { resolve } from "node:path";
+import { resolve, join } from "node:path";
+import { homedir } from "node:os";
 import { parse as parseYaml } from "yaml";
 
 export interface SentinelConfig {
@@ -27,6 +28,19 @@ export interface SentinelConfig {
     blockedModels?: string[];
   };
 }
+function defaultStoragePath(): string {
+  // Prefer XDG_DATA_HOME on Linux/macOS, fallback to ~/.local/share.
+  // On Windows, use LOCALAPPDATA.
+  const xdg = process.env.XDG_DATA_HOME;
+  if (xdg) return join(xdg, "sentinelai", "usage.db");
+
+  if (process.platform === "win32") {
+    const local = process.env.LOCALAPPDATA ?? join(homedir(), "AppData", "Local");
+    return join(local, "sentinelai", "usage.db");
+  }
+
+  return join(homedir(), ".local", "share", "sentinelai", "usage.db");
+}
 
 const DEFAULT_CONFIG: SentinelConfig = {
   scanner: {
@@ -34,7 +48,7 @@ const DEFAULT_CONFIG: SentinelConfig = {
     severityThreshold: "low",
   },
   cost: {
-    storage: "./sentinelai.db",
+    storage: defaultStoragePath(),
     proxyPort: 9191,
     budgets: [],
   },

--- a/packages/cost-tracker/src/storage/database.ts
+++ b/packages/cost-tracker/src/storage/database.ts
@@ -1,4 +1,6 @@
 import Database from "better-sqlite3";
+import { mkdirSync, chmodSync, existsSync } from "node:fs";
+import { dirname } from "node:path";
 import type { UsageRecord, CostReport, Budget } from "@sentinelai/core";
 
 const SCHEMA = `
@@ -49,9 +51,24 @@ export class CostDatabase {
   private db: Database.Database;
 
   constructor(dbPath: string) {
+    // Ensure parent directory exists and the DB file is created with
+    // restrictive permissions (0600) on POSIX. On Windows, chmod is a no-op.
+    const parent = dirname(dbPath);
+    if (parent && parent !== "." && !existsSync(parent)) {
+      mkdirSync(parent, { recursive: true, mode: 0o700 });
+    }
+
     this.db = new Database(dbPath);
     this.db.pragma("journal_mode = WAL");
     this.db.exec(SCHEMA);
+
+    if (process.platform !== "win32") {
+      try {
+        chmodSync(dbPath, 0o600);
+      } catch {
+        // Best effort — don't fail the caller if chmod isn't permitted.
+      }
+    }
   }
 
   insertUsage(record: UsageRecord): void {


### PR DESCRIPTION
## Summary
The cost-tracker SQLite DB is created in the current working directory at mode 0644, which (1) leaks usage/cost data on multi-user systems, and (2) clutters project roots with a binary that can be committed accidentally.

## Before
```
$ cd ~/sentinelai && node packages/cli/dist/index.js cost budget --set 100
$ ls -la sentinelai.db
-rw-r--r-- 1 kali kali 40960 Apr 20 06:49 sentinelai.db
```
## Fix
- Default `cost.storage` is now `$XDG_DATA_HOME/sentinelai/usage.db` on Linux/macOS (fallback `~/.local/share/sentinelai/usage.db`), and `%LOCALAPPDATA%\sentinelai\usage.db` on Windows.
- Parent directory is created with mode 0700 if missing.
- DB file is chmod'd to 0600 after creation on POSIX platforms.
- Explicit `cost.storage` config overrides still take precedence — no behaviour change for users who set an absolute path in `sentinelai.config.yaml`.

## After
```
$ node packages/cli/dist/index.js cost budget --set 100
$ stat -c '%a %n' ~/.local/share/sentinelai/usage.db
600 /home/kali/.local/share/sentinelai/usage.db
$ ls sentinelai.db 2>/dev/null
(nothing — cwd is clean)
```
Config override regression test:
```
$ cat sentinelai.config.yaml
cost:
storage: /tmp/test-config/mydb.sqlite
$ node packages/cli/dist/index.js cost budget --set 50
$ stat -c '%a %n' /tmp/test-config/mydb.sqlite
600 /tmp/test-config/mydb.sqlite
```
## Risk
Users who previously relied on the DB being in their project root will need to either copy the existing `./sentinelai.db` to the new location or set `cost.storage: ./sentinelai.db` in their config. The new file is created empty on first run.

Worth considering: a one-time notice on first run if a legacy `./sentinelai.db` is detected, pointing the user to the new default. Happy to add that in a follow-up.